### PR TITLE
Update wrong URLs in subscriptions

### DIFF
--- a/02-git-driven/01-commit-only/kargo.yaml
+++ b/02-git-driven/01-commit-only/kargo.yaml
@@ -106,7 +106,7 @@ metadata:
 spec:
   subscriptions:
   - git:
-      repoURL: https://github.com/krancour/kargo-demo-gitops-2.git
+      repoURL: https://github.com/<github-username>/kargo-demo-gitops.git
       branch: kustomize
 ---
 apiVersion: kargo.akuity.io/v1alpha1

--- a/02-git-driven/02-helm-driven/02-commit-n-image/kargo.yaml
+++ b/02-git-driven/02-helm-driven/02-commit-n-image/kargo.yaml
@@ -36,7 +36,7 @@ metadata:
 spec:
   subscriptions:
   - git:
-      repoURL: https://github.com/krancour/kargo-demo-gitops-2.git
+      repoURL: https://github.com/<github-username>/kargo-demo-gitops.git
       branch: new-helm
   - image:
       repoURL: public.ecr.aws/nginx/nginx

--- a/02-git-driven/03-kustomize-driven/02-commit-n-image/kargo.yaml
+++ b/02-git-driven/03-kustomize-driven/02-commit-n-image/kargo.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   subscriptions:
   - git:
-      repoURL: https://github.com/krancour/kargo-demo-gitops-2.git
+      repoURL: https://github.com/<github-username>/kargo-demo-gitops.git
       branch: kustomize
   - image:
       repoURL: public.ecr.aws/nginx/nginx


### PR DESCRIPTION
This also requires the `monorepo` branch to be pushed to https://github.com/krancour/kargo-demo-gitops.